### PR TITLE
Fix Ethereum get_blockByNumber RPC on Shiden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,24 +1378,6 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a67be3eaf296ef668733f54c637e84d0ca34eaf194f0077455135981ad464c3"
-dependencies = [
- "bytes 1.1.0",
- "ethereum-types",
- "hash-db",
- "hash256-std-hasher",
- "parity-scale-codec",
- "rlp",
- "rlp-derive",
- "serde",
- "sha3 0.9.1",
- "triehash",
-]
-
-[[package]]
-name = "ethereum"
-version = "0.9.0"
 source = "git+https://github.com/PlasmNetwork/ethereum?branch=polkadot-v0.9.11#2b98173bd88c05bfeefad421d260101b9008497b"
 dependencies = [
  "bytes 1.1.0",
@@ -1439,7 +1421,7 @@ version = "0.30.1"
 source = "git+https://github.com/PlasmNetwork/evm?branch=polkadot-v0.9.11#0f170ec4745e6d52f225c5f00b2426f883db0b01"
 dependencies = [
  "environmental",
- "ethereum 0.9.0 (git+https://github.com/PlasmNetwork/ethereum?branch=polkadot-v0.9.11)",
+ "ethereum",
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
@@ -1577,7 +1559,7 @@ dependencies = [
 name = "fc-rpc"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum",
  "ethereum-types",
  "evm",
  "fc-consensus",
@@ -1725,7 +1707,7 @@ dependencies = [
 name = "fp-consensus"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum",
  "parity-scale-codec",
  "rlp",
  "sha3 0.8.2",
@@ -1750,7 +1732,7 @@ dependencies = [
 name = "fp-rpc"
 version = "3.0.0-dev"
 dependencies = [
- "ethereum 0.9.0 (git+https://github.com/PlasmNetwork/ethereum?branch=polkadot-v0.9.11)",
+ "ethereum",
  "ethereum-types",
  "fp-evm",
  "parity-scale-codec",
@@ -1766,7 +1748,7 @@ dependencies = [
 name = "fp-self-contained"
 version = "1.0.0-dev"
 dependencies = [
- "ethereum 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum",
  "frame-support",
  "parity-scale-codec",
  "parity-util-mem",
@@ -4243,7 +4225,7 @@ dependencies = [
 name = "pallet-ethereum"
 version = "4.0.0-dev"
 dependencies = [
- "ethereum 0.9.0 (git+https://github.com/PlasmNetwork/ethereum?branch=polkadot-v0.9.11)",
+ "ethereum",
  "ethereum-types",
  "evm",
  "fp-consensus",

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -138,8 +138,8 @@ pub mod frontier_backend_client {
 		match client.storage(&at, &StorageKey(PALLET_ETHEREUM_SCHEMA.to_vec())) {
 			Ok(Some(bytes)) => Decode::decode(&mut &bytes.0[..])
 				.ok()
-				.unwrap_or(EthereumStorageSchema::Undefined),
-			_ => EthereumStorageSchema::Undefined,
+				.unwrap_or(EthereumStorageSchema::V1),
+			_ => EthereumStorageSchema::V1,
 		}
 	}
 


### PR DESCRIPTION
**Description**

Returns empty blocks in case of `pallet_ethereum` doesn't registered on chain.